### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 setting.py
+wp-config.php


### PR DESCRIPTION
#Descripción
¿Que ha cambiado?
Agregamos al gitignore.io soporte para wordpress

- [ ] Frontend
- [ ] Backend
- [x] Server

#Cómo puedo probar los cambios?
La configuración y credenciales ya no se van a ver en el repo
